### PR TITLE
solved issue #14 by using global lock

### DIFF
--- a/g2utils/um2grb2.py
+++ b/g2utils/um2grb2.py
@@ -570,10 +570,7 @@ def regridAnlFcstFiles(arg):
     nVars = len(cubes)
     
     accumutationType = ['rain', 'precip', 'snow']
-    
-    # create lock object
-    lock = mp.Lock()
-    
+           
     # open for-loop-1 -- for all the variables in the cube
     for varName, varSTASH in varNamesSTASH:
         # define variable name constraint
@@ -660,6 +657,8 @@ def regridAnlFcstFiles(arg):
             print "Going to be save into ", outFn
                         
             try:
+                # create lock object
+                lock = mp.Lock()
                 # lock other threads / processors from being access same file 
                 # to write other variables
                 lock.acquire()
@@ -670,6 +669,8 @@ def regridAnlFcstFiles(arg):
                 if str(e) == "The vertical-axis coordinate(s) ('soil_model_level_number') are not recognised or handled.":  
                     regdCube.remove_coord('soil_model_level_number') 
                     print "Removed soil_model_level_number from cube, due to error %s" % str(e)
+                    # create lock object
+                    lock = mp.Lock()
                     # lock other threads / processors from being access same file 
                     # to write other variables
                     lock.acquire()
@@ -687,7 +688,7 @@ def regridAnlFcstFiles(arg):
             # end of try:
             print "saved"
             # make memory free 
-            del regdCube
+            del regdCube, lock
             
             ## edit location section in grib2 to point to the right RMC
             # gribapi.grib_set(outFn,'centre','28')

--- a/g2utils/um2grb2.py
+++ b/g2utils/um2grb2.py
@@ -95,7 +95,8 @@ import datetime
 iris.FUTURE.strict_grib_load = True
 
 # -- Start coding
-
+# create lock object
+lock = mp.Lock()
 _current_date_ = None
 _startT_ = None
 _tmpDir_ = None
@@ -546,7 +547,7 @@ def regridAnlFcstFiles(arg):
     This module has been entirely revamped & improved by AAT based on an older and
     serial version by MNRS on 11/16/2015.
     """
-    global _targetGrid_, _current_date_, _startT_, _inDataPath_, _opPath_, _fext_
+    global _targetGrid_, _current_date_, _startT_, _inDataPath_, _opPath_, _fext_, lock
     
     fpname, hr = arg 
     
@@ -656,9 +657,7 @@ def regridAnlFcstFiles(arg):
             outFn = os.path.join(_opPath_, outFn)
             print "Going to be save into ", outFn
                         
-            try:
-                # create lock object
-                lock = mp.Lock()
+            try:                
                 # lock other threads / processors from being access same file 
                 # to write other variables
                 lock.acquire()
@@ -688,7 +687,7 @@ def regridAnlFcstFiles(arg):
             # end of try:
             print "saved"
             # make memory free 
-            del regdCube, lock
+            del regdCube
             
             ## edit location section in grib2 to point to the right RMC
             # gribapi.grib_set(outFn,'centre','28')

--- a/g2utils/um2grb2.py
+++ b/g2utils/um2grb2.py
@@ -95,8 +95,9 @@ import datetime
 iris.FUTURE.strict_grib_load = True
 
 # -- Start coding
-# create lock object
+# create global lock object
 lock = mp.Lock()
+# other global variables
 _current_date_ = None
 _startT_ = None
 _tmpDir_ = None
@@ -104,6 +105,7 @@ _inDataPath_ = None
 _opPath_ = None
 _targetGrid_ = None
 _fext_ = '_unOrdered'
+# global ordered variables (the order we want to write into grib2)
 _orderedVars_ = {'PressureLevel': [
 ## Pressure Level Variable names & STASH codes
 ('geopotential_height', 'm01s16i202'),           

--- a/scripts/configure
+++ b/scripts/configure
@@ -16,7 +16,7 @@ inPath = /gpfs3/home/umfcst/NCUM/fcst/
 outPath = /gpfs4/home/umtid/um2grb2/GRIB-parallel/
 
 ## working directory (used to create temporary log files)
-tmpPath = /gpfs2/home/umtid/test/
+tmpPath = /gpfs4/home/umtid/tmp/um2grb2/logs/
 
 ## By default date takes argument as YYYYMMDD (which means it assume today's date)
 ## But user can specify the different date by follwing the same format.

--- a/scripts/configure
+++ b/scripts/configure
@@ -13,7 +13,7 @@
 inPath = /gpfs3/home/umfcst/NCUM/fcst/
 
 ## model grib2 files path
-outPath = /gpfs2/home/umtid/test/GRIB-parallel/
+outPath = /gpfs4/home/umtid/um2grb2/GRIB-parallel/
 
 ## working directory (used to create temporary log files)
 tmpPath = /gpfs2/home/umtid/test/


### PR DESCRIPTION
Dear @raghu330 ,

In this pull request #16 I introduced lock in our um2grb2.py module.
Whoever writes the grib2 file after regridding, all other processors (say 39 out of 40) are at rest mode and resume it back once the first processor completed the file IO write operation (it hardly takes 3 sec to write into grib2 file).

Though we use global lock it doesn't affect much in net time consume, because it takes 10 minutes only to finish the following 3 tasks.
1. create all 44 grib2 files, 
2. then reading it for re-ordering variables and re-creating 44 files; 
3. after that finally creates 44 ctl, idx files. 

Thanks
Arulalan/T
